### PR TITLE
Update intl version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
 
 
   faker: ^2.1.0
-  intl: ^0.17.0
+  intl: ^0.18.0
   shared_preferences: ^2.0.20
 
 #  edfapg_sdk: 0.1.1


### PR DESCRIPTION
upgrade intl package because it is incompatible with a lot of other common packages like timeago the error message below
"'
Because every version of edfapg_sdk depends on intl ^0.17.0 and timeago 3.7.0 depends on intl >=0.18.0 <0.20.0, edfapg_sdk is incompatible with timeago 3.7.0. And because no versions of timeago match >3.7.0 <4.0.0, edfapg_sdk is incompatible with timeago ^3.7.0. '"

and also easy_localization package 
error message below

"Note: intl is pinned to version 0.19.0 by flutter_localizations from the flutter SDK. See https://dart.dev/go/sdk-version-pinning for details. "
Because every version of edfapg_sdk depends on intl ^0.17.0 and every version of flutter_localizations from sdk depends on intl 0.19.0, edfapg_sdk is incompatible with flutter_localizations from sdk. And because easy_localization 3.0.7 depends on flutter_localizations from sdk, edfapg_sdk is incompatible with easy_localization 3.0.7. "

"